### PR TITLE
Add ORCID support in for template awesome-cv

### DIFF
--- a/inst/rmarkdown/templates/awesomecv/resources/awesome-cv.tex
+++ b/inst/rmarkdown/templates/awesomecv/resources/awesome-cv.tex
@@ -82,6 +82,9 @@ $endif$
 $if(www)$
 \homepage{$www$}
 $endif$
+$if(orcid)$
+\orcid{$orcid$}
+$endif$
 $if(github)$
 \github{$github$}
 $endif$

--- a/inst/rmarkdown/templates/awesomecv/resources/awesome-cv.tex
+++ b/inst/rmarkdown/templates/awesomecv/resources/awesome-cv.tex
@@ -16,8 +16,6 @@
 % Template license:
 % CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
 %
-
-
 %-------------------------------------------------------------------------------
 % CONFIGURATIONS
 %-------------------------------------------------------------------------------
@@ -84,6 +82,15 @@ $if(www)$
 $endif$
 $if(orcid)$
 \orcid{$orcid$}
+$endif$
+$if(publons)$
+\publons{$publons$}
+$endif$
+$if(googlescholar)$
+\googlescholar{$googlescholar$}
+$endif$
+$if(researchgate)$
+\researchgate{$researchgate$}
 $endif$
 $if(github)$
 \github{$github$}

--- a/inst/rmarkdown/templates/awesomecv/skeleton/awesome-cv.cls
+++ b/inst/rmarkdown/templates/awesomecv/skeleton/awesome-cv.cls
@@ -76,9 +76,9 @@
 % (https://github.com/posquit0/latex-fontawesome)
 \defaultfontfeatures{Extension = .otf}
 \RequirePackage{fontawesome}
+% Add support of academia icons
+\usepackage{academicons}
 \RequirePackage[default,opentype]{sourcesanspro}
-% Needed for academia icons
-\RequirePackage{academicons}
 % Needed for the photo ID
 \RequirePackage[skins]{tcolorbox}
 % Needed to deal a paragraphs
@@ -292,6 +292,18 @@
 % Usage: \orcid{<orcid>}
 \newcommand*{\orcid}[1]{\def\@orcid{#1}}
 
+% Defines writer's Publons account (optional)
+% Usage: \publons{<publons>}
+\newcommand*{\publons}[1]{\def\@publons{#1}}
+
+% Defines writer's googlescholar account (optional)
+% Usage: \googlescholar{<googlescholar-user-id>}
+\newcommand*{\googlescholar}[1]{\def\@googlescholar{#1}}
+
+% Defines writer's scobus account (optional)
+% Usage: \researchgate{<researchgate-name>}
+\newcommand*{\researchgate}[1]{\def\@researchgate{#1}}
+
 % Defines writer's github (optional)
 % Usage: \github{<github-nick>}
 \newcommand*{\github}[1]{\def\@github{#1}}
@@ -466,6 +478,24 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{https://orcid.org/\@orcid}{\aiOrcidSquare\acvHeaderIconSep\@orcid}%
+        }%
+      \ifthenelse{\isundefined{\@publons}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://publons.com/researcher/\@publons}{\aiPublonsSquare\acvHeaderIconSep\@publons}%
+        }%
+      \ifthenelse{\isundefined{\@googlescholar}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://scholar.google.com/citations?user=\@googlescholar}{\aiGoogleScholarSquare\acvHeaderIconSep\@googlescholar}%
+        }%
+      \ifthenelse{\isundefined{\@researchgate}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://www.researchgate.net/profile/\@researchgate}{\aiResearchGateSquare\acvHeaderIconSep\@researchgate}%
         }%
       \ifthenelse{\isundefined{\@github}}%
         {}%

--- a/inst/rmarkdown/templates/awesomecv/skeleton/awesome-cv.cls
+++ b/inst/rmarkdown/templates/awesomecv/skeleton/awesome-cv.cls
@@ -77,6 +77,8 @@
 \defaultfontfeatures{Extension = .otf}
 \RequirePackage{fontawesome}
 \RequirePackage[default,opentype]{sourcesanspro}
+% Needed for academia icons
+\RequirePackage{academicons}
 % Needed for the photo ID
 \RequirePackage[skins]{tcolorbox}
 % Needed to deal a paragraphs
@@ -286,6 +288,10 @@
 % Usage: \homepage{<url>}
 \newcommand*{\homepage}[1]{\def\@homepage{#1}}
 
+% Defines writer's orcid (optional)
+% Usage: \orcid{<orcid>}
+\newcommand*{\orcid}[1]{\def\@orcid{#1}}
+
 % Defines writer's github (optional)
 % Usage: \github{<github-nick>}
 \newcommand*{\github}[1]{\def\@github{#1}}
@@ -454,6 +460,12 @@
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{http://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
+        }%
+      \ifthenelse{\isundefined{\@orcid}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://orcid.org/\@orcid}{\aiOrcidSquare\acvHeaderIconSep\@orcid}%
         }%
       \ifthenelse{\isundefined{\@github}}%
         {}%


### PR DESCRIPTION
I added support for ORCID in the awesome-cv template using the LaTeX package 'academicons'. 
I did not add news in NEWS.md and leave it to you. 