### PR TITLE
awesomecv: remove vspace if no why; fix issue 77

### DIFF
--- a/inst/rmarkdown/templates/awesomecv/resources/awesome-cv.tex
+++ b/inst/rmarkdown/templates/awesomecv/resources/awesome-cv.tex
@@ -107,7 +107,7 @@ $endif$
 % Arguments: what when with where why
 \usepackage{etoolbox}
 \def\detaileditem#1#2#3#4#5{%
-\cventry{#1}{#3}{#4}{#2}{\ifx#5\empty\else{\begin{cvitems}#5\end{cvitems}}\fi}}
+\cventry{#1}{#3}{#4}{#2}{\ifx#5\empty\else{\begin{cvitems}#5\end{cvitems}}\fi}\ifx#5\empty{\vspace{-4.0mm}}\else\fi}
 \def\detailedsection#1{\begin{cventries}#1\end{cventries}}
 
 % Templates for brief entries


### PR DESCRIPTION
fixes #77 by changing vitae's internal template for awesome-cv, while leaving base template for awesome-cv intact