### PR TITLE
knitr::write_bib() does not guarantee the number of bib entries

### DIFF
--- a/tests/testthat/test-entries.R
+++ b/tests/testthat/test-entries.R
@@ -38,7 +38,7 @@ test_that("detailed_entries", {
   print <- knitr::knit_print(entries)
 
   expect_match(print, "detailedsection")
-  expect_equal(NROW(entries), 2)
+  expect_equal(NROW(entries), length(RefManageR::ReadBib(tmpbib)))
   expect_equal(stringr::str_count(print, "detaileditem"), 2)
 
   expect_equal(stringr::str_count(print, "\\\\item"), 2)

--- a/tests/testthat/test-entries.R
+++ b/tests/testthat/test-entries.R
@@ -38,7 +38,7 @@ test_that("detailed_entries", {
   print <- knitr::knit_print(entries)
 
   expect_match(print, "detailedsection")
-  expect_equal(NROW(entries), length(RefManageR::ReadBib(tmpbib)))
+  expect_equal(NROW(entries), 2)
   expect_equal(stringr::str_count(print, "detaileditem"), 2)
 
   expect_equal(stringr::str_count(print, "\\\\item"), 2)
@@ -60,6 +60,7 @@ test_that("bibliography_entries", {
   print <- knitr::knit_print(entries)
 
   expect_match(print, "defbibheading")
+  expect_equal(NROW(entries), length(RefManageR::ReadBib(tmpbib)))
 
   expect_match(print, "rmarkdown")
   expect_match(print, "testthat")

--- a/tests/testthat/test-entries.R
+++ b/tests/testthat/test-entries.R
@@ -60,7 +60,6 @@ test_that("bibliography_entries", {
   print <- knitr::knit_print(entries)
 
   expect_match(print, "defbibheading")
-  expect_equal(NROW(entries), 2)
 
   expect_match(print, "rmarkdown")
   expect_match(print, "testthat")


### PR DESCRIPTION
With https://github.com/yihui/knitr/commit/9ecfae93cd1e573a6c5b290fe5d663e3f831e44e, `knitr::write_bib()` will also include entries from the package `CITATION` file, e.g.,

```r
> knitr::write_bib('rmarkdown')
@Manual{R-rmarkdown,
  title = {rmarkdown: Dynamic Documents for R},
  author = {JJ Allaire and Yihui Xie and Jonathan McPherson and Javier Luraschi and Kevin Ushey and Aron Atkins and Hadley Wickham and Joe Cheng and Winston Chang and Richard Iannone},
  note = {R package version 1.16.3},
  url = {https://github.com/rstudio/rmarkdown},
  year = {2019},
}
@Book{rmarkdown2018,
  title = {R Markdown: The Definitive Guide},
  author = {Yihui Xie and J.J. Allaire and Garrett Grolemund},
  publisher = {Chapman and Hall/CRC},
  address = {Boca Raton, Florida},
  year = {2018},
  note = {ISBN 9781138359338},
  url = {https://bookdown.org/yihui/rmarkdown},
}
```

So please do not test the number of bib entries in this package (if such a test is needed at all, the best place would be in **knitr** instead of **vitae**). Thank you!

P.S. Currently I'm preparing a new release of **knitr**, and this test will prevent me from submitting it to CRAN. I will truly appreciate it if you could send a new version of **vitae** in the near future.