### PR TITLE
No longer need to deal with header-includes in YAML metadata with rmarkdown >= 1.18

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,9 @@ Imports:
     rlang,
     glue,
     dplyr,
-    rmarkdown,
+    rmarkdown (>= 1.18),
     knitr,
+    xfun,
     RefManageR
 Suggests:
     bibtex,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Curriculum Vitae for R Markdown
 Version: 0.2.0.9000
 Authors@R: c(
   person("Mitchell", "O'Hara-Wild", role=c("aut", "cre"), email = "mail@mitchelloharawild.com", comment=c(ORCID = "0000-0001-6729-7695")),
-  person("Rob", "Hyndman", email="Rob.Hyndman@monash.edu", role=c("aut"), comment = c(ORCID = "0000-0002-2140-5352")))
+  person("Rob", "Hyndman", email="Rob.Hyndman@monash.edu", role=c("aut"), comment = c(ORCID = "0000-0002-2140-5352")),
+  person("Yihui", "Xie", role = c("ctb"), comment = c(ORCID = "0000-0003-0645-5666")))
 Description: Provides templates and functions to simplify the production and maintenance of curriculum vitae.
 Imports:
     bookdown,

--- a/R/cv_document.R
+++ b/R/cv_document.R
@@ -40,19 +40,9 @@ cv_document <- function(..., pandoc_args = NULL, pandoc_vars = NULL) {
       )
     }
 
-    if ("--include-in-header" %in% args) {
-      header_file <- args[which(args == "--include-in-header") + 1]
-    }
-    else {
-      header_file <- tempfile("cv-header", fileext = ".tex")
-      if ("header-includes" %in% names(metadata)) {
-        cat(c("", metadata[["header-includes"]]), sep = "\n", file = header_file, append = TRUE)
-      }
-      args <- c(args, rmarkdown::includes_to_pandoc_args(rmarkdown::includes(in_header = header_file)))
-    }
-
-    cat(header_contents, sep = "\n", file = header_file, append = TRUE)
-
+    header_file <- tempfile("cv-header", fileext = ".tex")
+    xfun::write_utf8(header_contents, header_file)
+    args <- c(args, rmarkdown::includes_to_pandoc_args(rmarkdown::includes(in_header = header_file)))
     args
   }
   config


### PR DESCRIPTION
This fixes rstudio/rmarkdown#1722. With rmarkdown 1.18, `header-includes` will always be written to a file, and included via `--include-in-header`: https://github.com/rstudio/rmarkdown/releases/tag/v1.18 so it no longer needs a special treatment in vitae.

The breakage on Travis CI seems to be from 1c25e22ba05f028f3b834bdb0bdfb7ae33f6faff and log is here: https://travis-ci.org/mitchelloharawild/vitae/builds/613832120. I guess I didn't break any tests in this PR.