### PR TITLE
Fixed issue with `citation_package` and `latex_engine` options not changeable by users for `cv_document` formats.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.2.0.9000
 Authors@R: c(
   person("Mitchell", "O'Hara-Wild", role=c("aut", "cre"), email = "mail@mitchelloharawild.com", comment=c(ORCID = "0000-0001-6729-7695")),
   person("Rob", "Hyndman", email="Rob.Hyndman@monash.edu", role=c("aut"), comment = c(ORCID = "0000-0002-2140-5352")),
-  person("Yihui", "Xie", role = c("ctb"), comment = c(ORCID = "0000-0003-0645-5666")))
+  person("Yihui", "Xie", role = c("ctb"), comment = c(ORCID = "0000-0003-0645-5666")),
+ person("JooYoung", "Seo", role="ctb", comment = c(ORCID = "0000-0002-4064-6012")))
 Description: Provides templates and functions to simplify the production and maintenance of curriculum vitae.
 Imports:
     bookdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed issue with `bibliography_entries()` not working on Windows.
 * Fixed issue with using `brief_entires()` / `detailed_entries()` mismatching argument order in variable names
+* Fixed issue with `citation_package` and `latex_engine` options not changeable by users for `cv_document` formats.
+
 
 # vitae 0.2.0
 

--- a/R/formats.R
+++ b/R/formats.R
@@ -14,34 +14,34 @@
 #' @rdname cv_formats
 #'
 #' @export
-hyndman <- function(...) {
+hyndman <- function(citation_package = "biblatex", ...) {
   template <- system.file("rmarkdown", "templates", "hyndman",
     "resources", "hyndmantemplate.tex",
     package = "vitae"
   )
-  cv_document(..., template = template, citation_package = "biblatex")
+  cv_document(..., template = template, citation_package = citation_package)
 }
 
 #' @rdname cv_formats
 #' @export
-twentyseconds <- function(...) {
+twentyseconds <- function(citation_package = "biblatex", ...) {
   template <- system.file("rmarkdown", "templates", "twentyseconds",
     "resources", "twentysecondstemplate.tex",
     package = "vitae"
   )
   copy_supporting_files("twentyseconds")
-  cv_document(..., template = template, citation_package = "biblatex")
+  cv_document(..., template = template, citation_package = citation_package)
 }
 
 #' @rdname cv_formats
 #' @export
-awesomecv <- function(...) {
+awesomecv <- function(citation_package = "biblatex", latex_engine = "xelatex", ...) {
   template <- system.file("rmarkdown", "templates", "awesomecv",
     "resources", "awesome-cv.tex",
     package = "vitae"
   )
   copy_supporting_files("awesomecv")
-  cv_document(..., template = template, citation_package = "biblatex", latex_engine = "xelatex")
+  cv_document(..., template = template, citation_package = citation_package, latex_engine = latex_engine)
 }
 
 #' @rdname cv_formats
@@ -49,7 +49,7 @@ awesomecv <- function(...) {
 #' @param theme The theme used for the template.
 #'
 #' @export
-moderncv <- function(..., theme = c("casual", "classic", "oldstyle", "banking", "fancy")) {
+moderncv <- function(citation_package = "biblatex", latex_engine = "pdflatex", theme = c("casual", "classic", "oldstyle", "banking", "fancy"), ...) {
   theme <- match.arg(theme)
   template <- system.file("rmarkdown", "templates", "moderncv",
     "resources", "moderncv.tex",
@@ -57,13 +57,13 @@ moderncv <- function(..., theme = c("casual", "classic", "oldstyle", "banking", 
   )
   copy_supporting_files("moderncv")
   cv_document(..., pandoc_vars = list(theme = theme),
-              template = template, citation_package = "biblatex", latex_engine = "pdflatex")
+              template = template, citation_package = citation_package, latex_engine = latex_engine)
 }
 
 #' @rdname cv_formats
 #'
 #' @export
-latexcv <- function(..., theme = c("classic", "modern", "rows", "sidebar", "two_column")) {
+latexcv <- function(citation_package = "biblatex", theme = c("classic", "modern", "rows", "sidebar", "two_column"), ...) {
   theme <- match.arg(theme)
   if(theme != "classic"){
     stop("Only the classic theme is currently supported.")
@@ -73,5 +73,5 @@ latexcv <- function(..., theme = c("classic", "modern", "rows", "sidebar", "two_
                           package = "vitae"
   )
   copy_supporting_files("latexcv")
-  cv_document(..., template = template, citation_package = "biblatex")
+  cv_document(..., template = template, citation_package = citation_package)
 }


### PR DESCRIPTION
Currently, `citation_package` and `latex_engine` options are locked by `vitae` package so that users cannot change their values when necessary.

For example, I had to use `citation_package: "none"` to test pandoc-citeproc when using lua-filter instead of biblatex.

Rather than hard-locking those values, we could suggested values as default and allow users to change them when necessary.
