### PR TITLE
added my vitae to the README.md file

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -134,6 +134,7 @@ Extending the package to add new templates is a somewhat simple process (details
 - [Han Zhang](https://github.com/HanZhang-psych/CV) (custom csl files)
 - [Bryan Jenks](https://github.com/tallguyjenks/CV)
 - [Lorena Abad](https://github.com/loreabad6/R-CV)
+- [Lampros Sp. Mouselimis](https://github.com/mlampros/My.CVitae) (using Github Actions and a docker image to programmatically generate the CV file)
 
 Add your vitae to the list using a PR.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ vignette).
 -   [Han Zhang](https://github.com/HanZhang-psych/CV) (custom csl files)
 -   [Bryan Jenks](https://github.com/tallguyjenks/CV)
 -   [Lorena Abad](https://github.com/loreabad6/R-CV)
+-   [Lampros Sp. Mouselimis](https://github.com/mlampros/My.CVitae)
+    (using Github Actions and a docker image to programmatically
+    generate the CV file)
 
 Add your vitae to the list using a PR.
 


### PR DESCRIPTION
Hi, 
first of all thanks for making this repository publicly available. I used the 'vitae' package and existing curriculum vitae from the README.md file to create my [CV file](https://github.com/mlampros/My.CVitae).
I thought it might be useful to add it as a reference in the README.md file of the repository (for R users), because it takes advantage of [Github Actions](https://github.com/mlampros/My.CVitae/blob/master/.github/workflows/docker_action.yml) and of a [docker image](https://hub.docker.com/r/mlampros/mycvitae) (that includes all dependencies) to programmatically generate the [cv.pdf](https://github.com/mlampros/My.CVitae/blob/master/docs/cv.pdf) file both in case of a Github push and on a weekly basis using a Github Actions cron-job.
In case of future pull requests like mine, I'd like to add that the [registration of an orchid developer application](https://github.com/ropensci/rorcid/issues/91#issuecomment-784985132) (access token) is required so that the user can knit the README.Rmd file and receive the modified README.md file