### PR TITLE
ModernCV: Add missing font icon commands

### DIFF
--- a/inst/rmarkdown/templates/moderncv/skeleton/moderncv.cls
+++ b/inst/rmarkdown/templates/moderncv/skeleton/moderncv.cls
@@ -320,9 +320,13 @@
 \newcommand*{\stackoverflowsocialsymbol} {}
 \newcommand*{\orcidsocialsymbol}   {}
 \newcommand*{\researchgatesocialsymbol}{}
-\newcommand*{\researchidsocialsymbol}{}
+\newcommand*{\researcheridsocialsymbol}{}
 \newcommand*{\googlescholarsocialsymbol}{}
 \newcommand*{\telegramsocialsymbol}{}
+\newcommand*{\whatsappsocialsymbol}{}
+\newcommand*{\signalsocialsymbol}{}
+\newcommand*{\matrixsocialsymbol}{}
+\newcommand*{\bornsymbol}{}
 
 % other
 %------


### PR DESCRIPTION
This fixes #176 for me. Solution is provided by @meflynn entirely. I don't understand this part of the code so I don't know if this is the right solution. 

I get the error in #176 both on Windows and Linux. I tried to update the github ubuntu runners to 18.04 or 20.04 to reproduce it in there, but stumbled upon other issues. So I don't know exactly what combination of system and software versions that causes this. 

