### PR TITLE
Extend #250 to call color vars in (most of) the other markdowncv templates

### DIFF
--- a/inst/rmarkdown/templates/markdowncv/skeleton/media/davewhipp-print.css
+++ b/inst/rmarkdown/templates/markdowncv/skeleton/media/davewhipp-print.css
@@ -57,6 +57,8 @@ body {
 	line-height: 1.35em;
 	/*also written as...  font: normal normal 400 100%/1.5em;*/
 	font-family: Avenir,Verdana,sans-serif;
+	color: var(--textcolor, black);
+	background-color: var(--backcolor, white);
 	/*margin-top: 1em;
 	margin-left: 1em;*/
 }
@@ -91,7 +93,7 @@ code {
 	font-size: 90%;
 	/*line-height: 1em;*/
 	font-family: Monaco,Menlo,monospace,sans-serif;
-	color: #ccc;
+	color: var(--codecolor, #ccc);
 }
 
 p code {
@@ -152,7 +154,7 @@ h1+p {
 
 h2 {
 	font-size: 1.1em;
-	color: #a00;
+	color: var(--headcolor, #a00);
 	margin-top: 2em;
 	position: relative;
 	top: 1.2em;
@@ -184,7 +186,7 @@ a:hover {
 	margin-top: 1em;
 	position: relative;
 	left: 25%;
-	color: #ccc;
+	color: var(--addresscolor, #ccc);
 	font-family: Monaco,Menlo,monospace,sans-serif;
 	font-size: 90%;
 }

--- a/inst/rmarkdown/templates/markdowncv/skeleton/media/davewhipp-screen.css
+++ b/inst/rmarkdown/templates/markdowncv/skeleton/media/davewhipp-screen.css
@@ -30,7 +30,7 @@ footer, header, hgroup, menu, nav, section {
 }
 body {
 	line-height: 1;
-	background-color: white;
+	background-color: var(--backcolor, white);
 }
 ol, ul {
 	list-style: none;
@@ -58,6 +58,7 @@ body {
 	line-height: 1.5em;
 	/*also written as...  font: normal normal 400 100%/1.5em;*/
 	font-family: Avenir,Verdana,sans-serif;
+	color: var(--textcolor, black);
 	margin-top: 1em;
 	margin-left: 1em;
 }
@@ -91,7 +92,7 @@ code {
 	font-size: 90%;
 	/*line-height: 1em;*/
 	font-family: Monaco,Menlo,monospace,sans-serif;
-	color: #aaa;
+	color: var(--codecolor, #aaa);
 }
 
 p code {
@@ -152,7 +153,7 @@ h1+p {
 
 h2 {
 	font-size: 1.1em;
-	color: #bc412b;
+	color: var(--headcolor, #bc412b);
 	margin-top: 3em;
 	position: relative;
 	top: 1.4em;
@@ -182,7 +183,7 @@ a:hover {
 	margin-top: 1em;
 	position: relative;
 	left: 25%;
-	color: #bc412b;
+	color: var(--addresscolor, #bc412b);
 	font-family: Monaco,Menlo,monospace,sans-serif;
 	font-size: 100%;
 }

--- a/inst/rmarkdown/templates/markdowncv/skeleton/media/kjhealy-print.css
+++ b/inst/rmarkdown/templates/markdowncv/skeleton/media/kjhealy-print.css
@@ -57,6 +57,8 @@ body {
 	line-height: 1.35em;
 	/*also written as...  font: normal normal 400 100%/1.5em;*/
 	font-family: Verdana,sans-serif;
+	color: var(--textcolor, black);
+	background-color: var(--backcolor, white);
 	/*margin-top: 1em;
 	margin-left: 1em;*/
 }
@@ -90,7 +92,7 @@ code {
 	font-size: 60%;
 	/*line-height: 1em;*/
 	font-family: Menlo,monospace,sans-serif;
-	color: #ccc;
+	color: var(--codecolor, #ccc);
 }
 
 p code {
@@ -150,7 +152,7 @@ h1+p {
 
 h2 {
 	font-size: 1.1em;
-	color: #a00;
+	color: var(--headcolor, #a00);
 	margin-top: 2em;
 	position: relative;
 	top: 1.2em;
@@ -182,7 +184,7 @@ a:hover {
 	margin-top: 1em;
 	position: relative;
 	left: 28%;
-	color: #ccc;
+	color: var(--addresscolor, #ccc);
 	font-family: Menlo,monospace,sans-serif;
 	font-size: 80%;
 }

--- a/inst/rmarkdown/templates/markdowncv/skeleton/media/kjhealy-screen.css
+++ b/inst/rmarkdown/templates/markdowncv/skeleton/media/kjhealy-screen.css
@@ -58,6 +58,8 @@ body {
 	line-height: 1.5em;
 	/*also written as...  font: normal normal 400 100%/1.5em;*/
 	font-family: Verdana,sans-serif;
+	color: var(--textcolor, black);
+	background-color: var(--backcolor, white);
 	margin-top: 1em;
 	margin-left: 1em;
 }
@@ -91,7 +93,7 @@ code {
 	font-size: 60%;
 	/*line-height: 1em;*/
 	font-family: Menlo,monospace,sans-serif;
-	color: #aaa;
+	color: var(--codecolor, #aaa);
 }
 
 p code {
@@ -151,7 +153,7 @@ h1+p {
 
 h2 {
 	font-size: 1.1em;
-	color: #a00;
+	color: var(--headcolor, #a00);
 	margin-top: 3em;
 	position: relative;
 	top: 1.4em;
@@ -181,7 +183,7 @@ a:hover {
 	margin-top: 1em;
 	position: relative;
 	left: 33%;
-	color: #aaa;
+	color: var(--addresscolor, #aaa);
 	font-family: Menlo,monospace,sans-serif;
 	font-size: 80%;
 }


### PR DESCRIPTION
Super small PR extending @ccbaumler's update (#250) that allows the markdowncv.html template to capture the following variables from the Rmd YAML header and feed them into the relevant CSS template:

> 1. `headcolor` changes the header (h2) color for the sections of the CV
> 1. `addresscolor` changes the webaddress bar containing the various icons and different user addresses
> 1. `codecolor` changes the code block color which is typically the when argument (i.e. the date in the final CV)
> 1. `backcolor` changes the background color of the document (for that dark mode!)
> 1. `textcolor` changes the text color of the document (so you can see the text in dark mode...)

I added the color variables to what I believe are the right spots in the kjhealy and davewhipp templates. Whenever specified, I left the original hard-coded color as the default color. (I didn't add them to the blmoore template just yet because that template has multiple header/subheader colors so I didn't want to make the call on which one should inherit `headcolor`.)