### PR TITLE
Adds new `font_scale` argument for `awesomecv()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vitae
 Title: Curriculum Vitae for R Markdown
-Version: 0.6.0
+Version: 0.6.0.1
 Authors@R: c(
   person("Mitchell", "O'Hara-Wild", role=c("aut", "cre"), email = "mail@mitchelloharawild.com", comment=c(ORCID = "0000-0001-6729-7695")),
   person("Rob", "Hyndman", email="Rob.Hyndman@monash.edu", role=c("aut"), comment = c(ORCID = "0000-0002-2140-5352")),
@@ -34,5 +34,5 @@ Encoding: UTF-8
 BugReports: https://github.com/mitchelloharawild/vitae/issues
 URL: https://pkg.mitchelloharawild.com/vitae/, https://github.com/mitchelloharawild/vitae
 Roxygen: list(markdown = TRUE, roclets=c('rd', 'collate', 'namespace'))
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# vitae 0.6.0.1
+
+## New features
+
+* `awesomecv`: added a `font_scale` argument to globally scale template font sizes.
+  Scaling is applied to a temporary copy of `awesome-cv.cls` at render time; the
+  default `1` preserves existing output. (@rempsyc, #275)
+
 # vitae 0.6.0
 
 ## New features

--- a/R/awesomecv.R
+++ b/R/awesomecv.R
@@ -8,6 +8,8 @@
 #' @inheritParams rmarkdown::pdf_document
 #' @param page_total If TRUE, the total number of pages is shown in the footer.
 #' @param show_footer If TRUE, a footer showing your name, document name, and page number.
+#' @param font_scale Numeric multiplier applied to hard-coded font sizes in the
+#' Awesome‑CV class (default = 1). Use values like 0.95–1.10.
 #'
 #' @section Preview:
 #' `r insert_preview("awesomecv")`
@@ -18,14 +20,26 @@
 #' ([@posquit0](https://github.com/posquit0))
 #'
 #' @export
-awesomecv <- function(..., latex_engine = "xelatex", page_total = FALSE,
-                      show_footer = TRUE) {
+awesomecv <- function(...,
+                      latex_engine = "xelatex",
+                      page_total = FALSE,
+                      show_footer = TRUE,
+                      font_scale = 1) {
   template <- system.file("rmarkdown", "templates", "awesomecv",
                           "resources", "awesome-cv.tex",
                           package = "vitae"
   )
   set_entry_formats(awesome_cv_entries)
   copy_supporting_files("awesomecv")
+
+  if (!isTRUE(all.equal(font_scale, 1))) {
+    cls_path <- "awesome-cv.cls"
+    if (!file.exists(cls_path)) {
+      stop("Expected 'awesome-cv.cls' in the working directory after copy_supporting_files().")
+    }
+    font_size_scaling(scale = font_scale, file_path = cls_path)
+  }
+
   pandoc_vars <- list()
   if(page_total) pandoc_vars$page_total <- TRUE
   if(show_footer) pandoc_vars$show_footer <- TRUE
@@ -61,3 +75,38 @@ awesome_cv_entries <- new_entry_formats(
     ), collapse = "\n")
   }
 )
+
+# Patches the local copy of awesome-cv.cls.
+# Strategy: inject \usepackage{xfp} and \newcommand\ACVscale{<scale>},
+# then convert \fontsize{<n>pt}{...} -> \fontsize{\fpeval{<n>*\ACVscale}pt}{...}
+font_size_scaling <- function(scale = 1, file_path = "awesome-cv.cls") {
+  stopifnot(is.numeric(scale), length(scale) == 1, scale > 0)
+  if (!file.exists(file_path)) stop("File not found: ", file_path)
+
+  x <- readLines(file_path, warn = FALSE)
+
+  # Insert just after fontspec so \fpeval is available before any uses
+  anchor <- grep("\\\\RequirePackage\\[quiet\\]\\{fontspec\\}", x, perl = TRUE)[1]
+  if (is.na(anchor)) anchor <- 0L
+
+  # Ensure xfp is loaded once
+  if (!any(grepl("\\\\usepackage\\{xfp\\}", x, perl = TRUE))) {
+    x <- append(x, "\\usepackage{xfp}", after = anchor); anchor <- anchor + 1L
+  }
+
+  # Replace any prior ACVscale defs, then provide+renew (idempotent update)
+  x <- x[!grepl("\\\\(re)?newcommand\\\\ACVscale|\\\\providecommand\\\\ACVscale", x, perl = TRUE)]
+  x <- append(x,
+              c("\\providecommand\\ACVscale{1}",
+                sprintf("\\renewcommand\\ACVscale{%.6f}", scale)),
+              after = anchor)
+
+  # Rewrite \fontsize{<n>pt}{...} -> \fontsize{\fpeval{<n>*\ACVscale}pt}{...}
+  # (Note the doubled backslashes in the R string to yield single backslashes in .cls)
+  x <- gsub("\\\\fontsize\\{([0-9.]+)pt\\}\\{",
+            "\\\\fontsize{\\\\fpeval{\\1*\\\\ACVscale}pt}{",
+            x, perl = TRUE)
+
+  writeLines(x, file_path)
+  message("Font sizes will be scaled by LaTeX (xfp) using ACVscale = ", scale, ".")
+}

--- a/man/awesomecv.Rd
+++ b/man/awesomecv.Rd
@@ -8,7 +8,8 @@ awesomecv(
   ...,
   latex_engine = "xelatex",
   page_total = FALSE,
-  show_footer = TRUE
+  show_footer = TRUE,
+  font_scale = 1
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ awesomecv(
 \item{page_total}{If TRUE, the total number of pages is shown in the footer.}
 
 \item{show_footer}{If TRUE, a footer showing your name, document name, and page number.}
+
+\item{font_scale}{Numeric multiplier applied to hard-coded font sizes in the
+Awesome‑CV class (default = 1). Use values like 0.95–1.10.}
 }
 \value{
 An R Markdown output format object.

--- a/tests/testthat/test-font-scale.R
+++ b/tests/testthat/test-font-scale.R
@@ -1,0 +1,50 @@
+skip_if_not(file.exists(system.file("rmarkdown","templates","awesomecv","resources","awesome-cv.tex", package = "vitae")))
+
+test_that("font_size_scaling injects xfp, defines ACVscale, and rewrites \\fontsize", {
+  cls <- tempfile(fileext = ".cls")
+  writeLines(c(
+    "\\ProvidesClass{awesome-cv}",
+    "\\RequirePackage[quiet]{fontspec}",
+    "\\newcommand*{\\headerfirstnamestyle}[1]{{\\fontsize{32pt}{1em}#1}}",
+    "\\newcommand*{\\entrytitlestyle}[1]{{\\fontsize{10pt}{1em}#1}}"
+  ), cls)
+
+  font_size_scaling(scale = 1.10, file_path = cls)
+
+  out <- readLines(cls, warn = FALSE)
+  expect_true(any(grepl("\\\\usepackage\\{xfp\\}", out)))
+  expect_equal(sum(grepl("\\\\providecommand\\\\ACVscale\\{1\\}", out)), 1L)
+  expect_true(any(grepl("\\\\renewcommand\\\\ACVscale\\{1\\.10", out)))
+  expect_true(any(grepl("\\\\fontsize\\{\\\\fpeval\\{32\\*\\\\ACVscale\\}pt\\}\\{1em\\}", out)))
+  expect_true(any(grepl("\\\\fontsize\\{\\\\fpeval\\{10\\*\\\\ACVscale\\}pt\\}\\{1em\\}", out)))
+
+  # Run again with a different scale: updates, no duplicates
+  font_size_scaling(scale = 0.95, file_path = cls)
+  out2 <- readLines(cls, warn = FALSE)
+  expect_equal(sum(grepl("\\\\usepackage\\{xfp\\}", out2)), 1L)
+  expect_equal(sum(grepl("\\\\providecommand\\\\ACVscale\\{1\\}", out2)), 1L)
+  expect_true(any(grepl("\\\\renewcommand\\\\ACVscale\\{0\\.95", out2)))
+})
+
+test_that("awesomecv copies resources and conditionally patches class", {
+  tmp <- tempfile("vitae-fontscale-")
+  dir.create(tmp)
+  old <- getwd()
+  on.exit({ setwd(old); unlink(tmp, recursive = TRUE, force = TRUE) }, add = TRUE)
+  setwd(tmp)
+
+  # No patch when font_scale = 1
+  awesomecv(font_scale = 1)
+  expect_true(file.exists("awesome-cv.cls"))
+  base_cls <- readLines("awesome-cv.cls", warn = FALSE)
+  expect_false(any(grepl("\\\\usepackage\\{xfp\\}", base_cls)))
+  expect_false(any(grepl("\\\\ACVscale", base_cls)))
+  expect_false(any(grepl("\\\\fontsize\\{\\\\fpeval\\{", base_cls)))
+
+  # Patch when font_scale != 1
+  awesomecv(font_scale = 1.05)
+  patched <- readLines("awesome-cv.cls", warn = FALSE)
+  expect_true(any(grepl("\\\\usepackage\\{xfp\\}", patched)))
+  expect_true(any(grepl("\\\\renewcommand\\\\ACVscale\\{1\\.05", patched)))
+  expect_true(any(grepl("\\\\fontsize\\{\\\\fpeval\\{[0-9.]+\\*\\\\ACVscale\\}pt\\}\\{", patched)))
+})

--- a/vitae.Rproj
+++ b/vitae.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 1451009f-2dcb-4378-b90c-8826e7b4aae3
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
Adds new `font_scale` argument for `awesomecv()` (fixes #81, #122, #198.)

---

`font_scale = 1` (default):

<img width="70%" height="872" alt="Image" src="https://github.com/user-attachments/assets/945712f5-7e59-4bb0-a1e9-80b04c1aae6f" />

`font_scale = 1.5`

<img width="70%" height="995" alt="Image" src="https://github.com/user-attachments/assets/49e8a206-f481-42fd-bf76-6c2e35e89cb1" />

Notice that the "I poisoned myself doing research" paragraph wasn't rescaled. This needs to be rescaled manually by the user with e.g,. `\Large` before the relevant text.

<img width="70%" height="1103" alt="Image" src="https://github.com/user-attachments/assets/98a93367-20fb-41a4-a7c7-641b3ab9b5ca" />